### PR TITLE
fix bug "An unsupported chargingState x was provided"

### DIFF
--- a/weconnect/elements/charging_status.py
+++ b/weconnect/elements/charging_status.py
@@ -100,6 +100,7 @@ class ChargingStatus(GenericStatus):
     class ChargingState(Enum,):
         OFF = 'off'
         READY_FOR_CHARGING = 'readyForCharging'
+        CHARGE_PURPOSE_REACHED = 'chargePurposeReachedAndNotConservationCharging'
         CHARGING = 'charging'
         ERROR = 'error'
         UNKNOWN = 'unknown charging state'


### PR DESCRIPTION

I found an additional chargingState value when my vehicle was fully charged but still plugged in - added it to the enum.