### PR TITLE
Add proxy support

### DIFF
--- a/weconnect/auth/my_cupra_session.py
+++ b/weconnect/auth/my_cupra_session.py
@@ -61,6 +61,7 @@ class MyCupraSession(VWWebSession):
                         backoff_factor=0.1,
                         status_forcelist=[500],
                         raise_on_status=False)
+        websession.proxies.update(self.proxies)
         websession.mount('https://', HTTPAdapter(max_retries=retries))
         websession.headers = CaseInsensitiveDict({
             'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',

--- a/weconnect/auth/we_charge_session.py
+++ b/weconnect/auth/we_charge_session.py
@@ -67,6 +67,7 @@ class WeChargeSession(VWWebSession):
                         backoff_factor=0.1,
                         status_forcelist=[500],
                         raise_on_status=False)
+        websession.proxies.update(self.proxies)
         websession.mount('https://', HTTPAdapter(max_retries=retries))
         websession.headers = CaseInsensitiveDict({
             'user-agent': 'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 '

--- a/weconnect/auth/we_connect_session.py
+++ b/weconnect/auth/we_connect_session.py
@@ -107,6 +107,7 @@ class WeConnectSession(VWWebSession):
                         backoff_factor=0.1,
                         status_forcelist=[500],
                         raise_on_status=False)
+        websession.proxies.update(self.proxies)
         websession.mount('https://', HTTPAdapter(max_retries=retries))
         websession.headers = CaseInsensitiveDict({
             'user-agent': 'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 '

--- a/weconnect/weconnect.py
+++ b/weconnect/weconnect.py
@@ -82,7 +82,7 @@ class WeConnect(AddressableObject):  # pylint: disable=too-many-instance-attribu
         self.proxy: Optional[str] = proxy
 
         if proxy:
-            self.proxystring = {'http': 'http://' + self.proxy, 'https': 'http://'+ self.proxy}
+            self.proxystring = {'http': 'http://' + self.proxy, 'https': 'http://' + self.proxy}
         else:
             self.proxystring = ""
 

--- a/weconnect/weconnect.py
+++ b/weconnect/weconnect.py
@@ -35,6 +35,7 @@ class WeConnect(AddressableObject):  # pylint: disable=too-many-instance-attribu
         updateAfterLogin: bool = True,
         loginOnInit: bool = False,
         fixAPI: bool = True,
+        proxy: Optional[str] = None,
         maxAge: Optional[int] = None,
         maxAgePictures: Optional[int] = None,
         updateCapabilities: bool = True,
@@ -55,6 +56,7 @@ class WeConnect(AddressableObject):  # pylint: disable=too-many-instance-attribu
             Defaults to True.
             loginOnInit (bool, optional): Login after initialization (If set to false, login needs to be called manually). Defaults to True.
             fixAPI (bool, optional): Automatically fix known issues with the WeConnect responses. Defaults to True.
+            proxy (str, optional): Set a proxy IP adress and port
             maxAge (int, optional): Maximum age of the cache before date is fetched again. None means no caching. Defaults to None.
             maxAgePictures (Optional[int], optional):  Maximum age of the pictures in the cache before date is fetched again. None means no caching.
             Defaults to None.
@@ -77,6 +79,13 @@ class WeConnect(AddressableObject):  # pylint: disable=too-many-instance-attribu
         self.__controls: GeneralControls = GeneralControls(localAddress='controls', parent=self)
         self.__cache: Dict[str, Any] = {}
         self.fixAPI: bool = fixAPI
+        self.proxy: Optional[str] = proxy
+        
+        if proxy:
+            self.proxystring = {'http': 'http://' + self.proxy, 'https': 'http://'+ self.proxy}
+        else:
+            self.proxystring = ""
+        
         self.maxAge: Optional[int] = maxAge
         self.maxAgePictures: Optional[int] = maxAgePictures
         self.latitude: Optional[float] = None
@@ -94,6 +103,7 @@ class WeConnect(AddressableObject):  # pylint: disable=too-many-instance-attribu
 
         self.__manager = SessionManager(tokenstorefile=tokenfile)
         self.__session = self.__manager.getSession(Service.WE_CONNECT, SessionUser(username=username, password=password))
+        self.__session.proxies.update(self.proxystring)
         self.__session.timeout = timeout
         self.__session.retries = numRetries
         self.__session.forceReloginAfter = forceReloginAfter

--- a/weconnect/weconnect.py
+++ b/weconnect/weconnect.py
@@ -80,12 +80,12 @@ class WeConnect(AddressableObject):  # pylint: disable=too-many-instance-attribu
         self.__cache: Dict[str, Any] = {}
         self.fixAPI: bool = fixAPI
         self.proxy: Optional[str] = proxy
-        
+
         if proxy:
             self.proxystring = {'http': 'http://' + self.proxy, 'https': 'http://'+ self.proxy}
         else:
             self.proxystring = ""
-        
+
         self.maxAge: Optional[int] = maxAge
         self.maxAgePictures: Optional[int] = maxAgePictures
         self.latitude: Optional[float] = None


### PR DESCRIPTION
Hi! First contribution to FOSS in a while, so mit Git may be a bit rusty.

I wanted to get the API running behind my companies proxy system so I added an optional proxy string to the API that will use the session.proxies.update method to set the proxy adresses of both the main session as well as the "websession" that's used in the doWebAuth methods.
It seems to work well for me so far (starting / stopping / checking climatization of my e-Up), so I chose to share it.

It's my first time working with an "online" project, so perhaps there would've been an easier way to implement this.