### PR TITLE
Add new error state fail_plug_disconnected

### DIFF
--- a/weconnect/elements/generic_status.py
+++ b/weconnect/elements/generic_status.py
@@ -184,5 +184,6 @@ class GenericStatus(AddressableObject):
             FAIL_BATTERY_LOW = 'fail_battery_low'
             FAIL_PLUG_ERROR = 'fail_plug_error'
             FAIL_CHARGE_PLUG_NOT_CONNECTED = 'fail_charge_plug_not_connected'
+            FAIL_PLUG_DISCONNECTED = 'fail_plug_disconnected'
             FAIL_NO_EXTERNAL_POWER = 'fail_no_external_power'
             UNKNOWN = 'unknown status'


### PR DESCRIPTION
I'm using [volkswagen_we_connect_id](https://github.com/mitch-dc/volkswagen_we_connect_id) which is based on this library and recently started seeing the following error message:

```text
/vehicles/<VIN>/domains/charging/chargingStatus/request/<Guid>/status: An unsupported status: fail_plug_disconnected was provided, known values are [successful, fail, polling_timeout, in_progress, queued, delayed, timeout, fail_vehicle_is_offline, fail_ignition_on, fail_battery_low, fail_plug_error, fail_charge_plug_not_connected, fail_no_external_power, unknown status] please report this as a bug
```

This PR adds this new error state being returned by the API. I chose the enum to add it to based on the list of other currently supported states.