### PR TITLE
Downgrading requests as HomeAssistant doesn't currently allow version…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests~=2.28.2
+requests~=2.28.1
 oauthlib~=3.2.2


### PR DESCRIPTION
Hi,
Wondering if it is possible to downgrade requests library to version 2.28.1? as HomeAssistant doesn't allow 2.28.2 yet and won't be updated untill April. 

Issue today is that https://github.com/mitch-dc/volkswagen_we_connect_id uses this library and it breaks cause of dependency missmatch.