### PR TITLE
Add unknown attributes reported from ID.7

### DIFF
--- a/weconnect/elements/battery_status.py
+++ b/weconnect/elements/battery_status.py
@@ -17,6 +17,8 @@ class BatteryStatus(GenericStatus):
     ):
         self.currentSOC_pct = AddressableAttribute(
             localAddress='currentSOC_pct', parent=self, value=None, valueType=int)
+        self.navigationTargetSOC_pct = AddressableAttribute(
+            localAddress='navigationTargetSOC_pct', parent=self, value=None, valueType=int)
         self.cruisingRangeElectric_km = AddressableAttribute(
             localAddress='cruisingRangeElectric_km', value=None, parent=self, valueType=int)
         super().__init__(vehicle=vehicle, parent=parent, statusId=statusId, fromDict=fromDict, fixAPI=fixAPI)
@@ -45,17 +47,21 @@ class BatteryStatus(GenericStatus):
                 self.cruisingRangeElectric_km.enabled = False
 
             self.currentSOC_pct.fromDict(fromDict['value'], 'currentSOC_pct')
+            self.navigationTargetSOC_pct.fromDict(fromDict['value'], 'navigationTargetSOC_pct')
         else:
             self.currentSOC_pct.enabled = False
             self.cruisingRangeElectric_km.enabled = False
+            self.navigationTargetSOC_pct.enabled = False
 
         super().update(fromDict=fromDict, ignoreAttributes=(
-            ignoreAttributes + ['currentSOC_pct', 'cruisingRangeElectric_km']))
+            ignoreAttributes + ['currentSOC_pct', 'navigationTargetSOC_pct', 'cruisingRangeElectric_km']))
 
     def __str__(self):
         string = super().__str__()
         if self.currentSOC_pct.enabled:
             string += f'\n\tCurrent SoC: {self.currentSOC_pct.value}%'
+        if self.navigationTargetSOC_pct.enabled:
+            string += f'\n\tNavigation Target SoC: {self.navigationTargetSOC_pct.value}%'
         if self.cruisingRangeElectric_km.enabled:
             if self.cruisingRangeElectric_km.value is not None:
                 string += f'\n\tRange: {self.cruisingRangeElectric_km.value}km'

--- a/weconnect/elements/temperature_battery_status.py
+++ b/weconnect/elements/temperature_battery_status.py
@@ -22,7 +22,7 @@ class TemperatureBatteryStatus(GenericStatus):
 
     def update(self, fromDict, ignoreAttributes=None):
         ignoreAttributes = ignoreAttributes or []
-        LOG.debug('Update range status from dict')
+        LOG.debug('Update battery temperature status from dict')
 
         if 'value' in fromDict:
             self.temperatureHvBatteryMin_K.fromDict(fromDict['value'], 'temperatureHvBatteryMin_K')

--- a/weconnect/elements/temperature_outside_status.py
+++ b/weconnect/elements/temperature_outside_status.py
@@ -1,0 +1,39 @@
+import logging
+
+from weconnect.addressable import AddressableAttribute
+from weconnect.elements.generic_status import GenericStatus
+from weconnect.util import kelvinToCelsius
+
+LOG = logging.getLogger("weconnect")
+
+
+class TemperatureOutsideStatus(GenericStatus):
+    def __init__(
+        self,
+        vehicle,
+        parent,
+        statusId,
+        fromDict=None,
+        fixAPI=True,
+    ):
+        self.temperatureOutside_K = AddressableAttribute(localAddress='temperatureOutside_K', parent=self, value=None, valueType=float)
+        super().__init__(vehicle=vehicle, parent=parent, statusId=statusId, fromDict=fromDict, fixAPI=fixAPI)
+
+    def update(self, fromDict, ignoreAttributes=None):
+        ignoreAttributes = ignoreAttributes or []
+        LOG.debug('Update outside temperature status from dict')
+
+        if 'value' in fromDict:
+            self.temperatureOutside_K.fromDict(fromDict['value'], 'temperatureOutside_K')
+
+        else:
+            self.temperatureOutside_K.enabled = False
+
+        super().update(fromDict=fromDict, ignoreAttributes=(ignoreAttributes
+                                                            + ['temperatureOutside_K']))
+
+    def __str__(self):
+        string = super().__str__()
+        if self.temperatureOutside_K.enabled:
+            string += f'\n\tOutside temperature {kelvinToCelsius(self.temperatureOutside_K.value)}°C'
+        return string

--- a/weconnect/elements/vehicle.py
+++ b/weconnect/elements/vehicle.py
@@ -46,6 +46,7 @@ from weconnect.elements.odometer_measurement import OdometerMeasurement
 from weconnect.elements.range_measurements import RangeMeasurements
 from weconnect.elements.readiness_status import ReadinessStatus
 from weconnect.elements.temperature_battery_status import TemperatureBatteryStatus
+from weconnect.elements.temperature_outside_status import TemperatureOutsideStatus
 from weconnect.elements.charging_profiles import ChargingProfiles
 from weconnect.elements.trip import Trip
 from weconnect.errors import APICompatibilityError, RetrievalError, APIError, TooManyRequestsError
@@ -309,6 +310,7 @@ class Vehicle(AddressableObject):  # pylint: disable=too-many-instance-attribute
                 'oilLevelStatus': GenericStatus,
                 'measurements': GenericStatus,
                 'temperatureBatteryStatus': TemperatureBatteryStatus,
+                'temperatureOutsideStatus': TemperatureOutsideStatus,
                 'fuelLevelStatus': FuelLevelStatus,
             },
             Domain.BATTERY_SUPPORT: {


### PR DESCRIPTION
There were 2 unknown attributes reported when integrated with ID.7:
```
[weconnect] /vehicles/WVWZZZED5RE..../domains/charging/batteryStatus: Unknown attribute navigationTargetSOC_pct with value 0
[weconnect] /vehicles/WVWZZZED5RE...: Unknown attribute temperatureOutsideStatus with value {'value': {'carCapturedTimestamp': '2024-05-24T13:42:02.711Z', 'temperatureOutside_K': '293.15'}} in domain measurements
```

Added them, now they are reporting correct values:
```
[charging] Elements: 6 items
        [batteryStatus] (last captured 2024-05-24T13:42:08+00:00)
                Current SoC: 60%
                Navigation Target SoC: 0%
                Range: 347km
```

```
[measurements] Elements: 5 items
        [temperatureOutsideStatus] (last captured 2024-05-24T13:42:02+00:00)
                Outside temperature 20.0°C
```
