### PR TITLE
Add missing icon color

### DIFF
--- a/weconnect/elements/warning_lights_status.py
+++ b/weconnect/elements/warning_lights_status.py
@@ -163,5 +163,6 @@ class WarningLightsStatus(GenericStatus):
         class IconColor(Enum,):
             YELLOW = 'Yellow'
             RED = 'Red'
+            WHITE = 'White'
             ICON_NOT_FOUND = 'ICON_NOT_FOUND'
             UNKNOWN = 'unknown color'


### PR DESCRIPTION
Addressing this error message:

> WARNING:weconnect:/vehicles/WVWXXX/domains/vehicleHealthWarnings/warningLights/warningLights/0xA21E/iconColor: An unsupported iconColor: White was provided, known values are [Yellow, Red, ICON_NOT_FOUND, unknown color] please report this as a bug

Vehicle: VW ID.3 - Software 3.7